### PR TITLE
fix: refactor adjust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Popup 是对 Overlay 的封装，children作为触发节点，弹出一个浮层
 | onRequestClose         | 弹层请求关闭时触发事件的回调函数                       | Function       | () => {} |
 | target                 | 弹层定位的参照元素                                  | Function            | （）=> document.body |
 | points                 | 弹层相对于参照元素的定位                             | [point, point] | ['tl', 'bl'] |
+| placement              | 部分points的简写模式<br/><br/>**可选值**:<br/>'t'(上，对应 points: ['bc', 'tc'])<br/>'r'(右，对应 points: ['lc', 'rc'])<br/>'b'(下，对应 points: ['tc', 'bc'])<br/>'l'(左，对应 points: ['rc', 'lc'])<br/>'tl'(上左，对应 points: ['bl', 'tl'])<br/>'tr'(上右，对应 points: ['br', 'tr'])<br/>'bl'(下左，对应 points: ['tl', 'bl'])<br/>'br'(下右，对应 points: ['tr', 'br'])<br/>'lt'(左上，对应 points: ['rt', 'lt'])<br/>'lb'(左下，对应 points: ['rb', 'lb'])<br/>'rt'(右上，对应 points: ['lt', 'rt'])<br/>'rb'(右下，对应 points: ['lb', 'rb'])                                                                           | Enum           | 'bl'                                                            |      |
 | offset                 | 弹层相对于trigger的定位的微调, 接收数组[hoz, ver], 表示弹层在 left / top 上的增量<br/>e.g. [100, 100] 表示往右、下分布偏移100px | Array          | [0, 0]|
 | container              | 渲染组件的容器，如果是函数需要返回 ref，如果是字符串则是该 DOM 的 id，也可以直接传入 DOM 节点 | any            | - |
 | hasMask                | 是否显示遮罩 | Boolean        | false |

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@alifd/next": "1.x",
     "@commitlint/cli": "^8.3.6",
     "@iceworks/spec": "^1.0.0",
+    "@types/jest": "^26.0.24",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -25,6 +25,7 @@ import {
   getFocusNodeList,
   isSameObject,
   useEvent,
+  getWidthHeight,
 } from './utils';
 import OverlayContext from './overlay-context';
 
@@ -285,12 +286,14 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>((props, ref) => {
 
         // 1. 这里提前先设置好 position 属性，因为有的节点可能会因为设置了 position 属性导致宽度变小
         // 2. 设置 visibility 先把弹窗藏起来，避免影响视图
-        // 3. 因为未知原因，原先 left&top 设置为 -1000的方式隐藏会导致获取到的overlay元素宽高不对，所以这里使用 visibility 方式处理
-        // https://drafts.csswg.org/css-position/#abspos-layout 未在此处找到相关解释，但设置为0 使其在可视区域内，可以获取到渲染后正确的宽高
+        // 3. 因为未知原因，原先 left&top 设置为 -1000的方式隐藏会导致获取到的overlay元素宽高不对
+        // https://drafts.csswg.org/css-position/#abspos-layout 未在此处找到相关解释，可能是浏览器优化，但使其有部分在可视区域内，就可以获取到渲染后正确的宽高, 然后使用visibility隐藏
+        const nodeRect = getWidthHeight(node);
         setStyle(node, {
           position: fixed ? 'fixed' : 'absolute',
-          top: 0,
-          left: 0,
+          // 这里 -nodeRect.width 是避免添加到容器内导致容器出现宽高变化， +1 是为了能确保有一部分在可视区域内
+          top: -nodeRect.height + 1,
+          left: -nodeRect.width + 1,
           visibility: 'hidden',
         });
 

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -295,9 +295,12 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>((props, ref) => {
         });
 
         const waitTime = 100;
-        ro.current = new ResizeObserver(throttle(updatePosition, waitTime));
+        const throttledUpdatePosition = throttle(updatePosition, waitTime);
+        ro.current = new ResizeObserver(throttledUpdatePosition);
         ro.current.observe(containerNode);
         ro.current.observe(node);
+        // fist call, 不依赖 ResizeObserver observe时的首次执行(测试环境不会执行)，因为 throttle 原因也不会执行两次
+        throttledUpdatePosition();
 
         forceUpdate({});
 

--- a/src/placement.ts
+++ b/src/placement.ts
@@ -408,12 +408,12 @@ function autoAdjustPosition(
   let left = l;
   let top = t;
   const { viewport, container, containerInfo } = staticInfo;
-  const { left: cLeft, top: cTop } = containerInfo;
+  const { left: cLeft, top: cTop, scrollLeft, scrollTop } = containerInfo;
 
   // 此时left&top是相对于container的，若container不是 viewport，则需要调整为相对 viewport 的 left & top 再计算
   if (viewport !== container) {
-    left += cLeft;
-    top += cTop;
+    left += cLeft - scrollLeft;
+    top += cTop - scrollTop;
   }
 
   // 根据位置超出情况，获取所有可以尝试的位置列表

--- a/src/placement.ts
+++ b/src/placement.ts
@@ -529,7 +529,7 @@ export default function getPlacements(config: PlacementsConfig): PositionResult 
   let { left, top, points } = getXY(placement, staticInfo);
 
   // step2: 根据 viewport（挂载容器不一定是可视区, eg: 挂载在父节点，但是弹窗超出父节点）重新计算位置. 根据可视区域优化位置
-  // 位置动态优化思路见 https://github.com/alibaba-fusion/overlay/issues/2
+  // 位置动态优化思路见 https://github.com/alibaba-fusion/overlay/issues/23
   if (autoAdjust && placement && shouldResizePlacement(left, top, viewport, staticInfo)) {
     const adjustResult = autoAdjustPosition(left, top, placement, staticInfo);
 

--- a/src/placement.ts
+++ b/src/placement.ts
@@ -267,20 +267,7 @@ function getNewPlacements(
     forbid('l', 'lt', 'lb');
   }
 
-  const allPlacements: placementType[] = [
-    't',
-    'tl',
-    'tr',
-    'r',
-    'rt',
-    'rb',
-    'b',
-    'bl',
-    'br',
-    'l',
-    'lt',
-    'lb',
-  ];
+  const allPlacements = Object.keys(placementMap) as placementType[];
   // 过滤出所有可用的
   const canTryPlacements = allPlacements.filter((t) => !forbiddenSet.has(t));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,7 +159,7 @@ export function getViewPort(container: HTMLElement) {
     const overflow = getStyle(calcContainer, 'overflow');
     // 若遇到滚动容器
     if (overflow?.match(/auto|scroll|hidden/)) {
-      // 若元素不是绝对定位元素，或滚动容器也是绝对定位元素，则使用改滚动容器作为视口
+      // 若 container 不是绝对定位，或者滚动容器也是也对定位，没有跳出滚动容器，使用滚动容器作为可视区域
       if (
         !isPositionContainer ||
         ['fixed', 'absolute'].includes(getStyle(calcContainer, 'position'))
@@ -171,7 +171,7 @@ export function getViewPort(container: HTMLElement) {
     calcContainer = calcContainer.parentNode as HTMLElement;
   }
 
-  // 其他情况均使用根节点作为视口
+  // 其他情况均使用浏览器的可视区域
   return document.documentElement;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -237,8 +237,7 @@ function getContentClippedElement(element: HTMLElement) {
 function getOffsetParent(element: HTMLElement): HTMLElement | null {
   let { offsetParent } = element;
   while (offsetParent && ['table', 'th', 'td'].includes(offsetParent.tagName.toLowerCase())) {
-    // @ts-ignore
-    offsetParent = offsetParent.offsetParent;
+    offsetParent = (offsetParent as HTMLElement).offsetParent;
   }
   return offsetParent as HTMLElement;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -151,20 +151,21 @@ export const getOverflowNodes = (targetNode: HTMLElement, container: HTMLElement
  * @returns
  */
 export function getViewPort(container: HTMLElement) {
-  const isScrollElement = (element: HTMLElement) => {
+  const isContentClippedElement = (element: HTMLElement) => {
     return getStyle(element, 'overflow') !== 'visible';
   };
 
   // 若 container 本身就是滚动容器，则直接返回
-  if (isScrollElement(container)) {
+  if (isContentClippedElement(container)) {
     return container;
   }
 
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
   // 若container为 fixed 或者相对于body定位，则代表其跳出父级滚动容器(若有)，此时使用浏览器视口作为可视区域调整位置
-  if (!container.offsetParent) {
+  const { offsetParent } = container;
+  if (!offsetParent || offsetParent === document.body) {
     // 若container定位节点为body，且body有滚动，则使用body作为可视区域
-    if (container.offsetParent === document.body && isScrollElement(document.body)) {
+    if (offsetParent === document.body && isContentClippedElement(document.body)) {
       return document.body;
     }
     return document.documentElement;
@@ -174,7 +175,7 @@ export function getViewPort(container: HTMLElement) {
   let scroller: HTMLElement = container.parentElement;
   while (scroller) {
     // 若遇到滚动容器则返回
-    if (isScrollElement(scroller)) {
+    if (isContentClippedElement(scroller)) {
       return scroller;
     }
     // 继续向上寻找

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -270,7 +270,10 @@ export function getViewPort(container: HTMLElement) {
     }
   }
 
-  return getContentClippedElement(container.parentElement) || fallbackViewportElement;
+  if (container.parentElement) {
+    return getContentClippedElement(container.parentElement) || fallbackViewportElement;
+  }
+  return fallbackViewportElement;
 }
 
 export function getStyle(elt: Element, name: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,15 +153,25 @@ export const getOverflowNodes = (targetNode: HTMLElement, container: HTMLElement
 export function getViewPort(container: HTMLElement) {
   let calcContainer: HTMLElement = container;
 
+  const isPositionContainer = ['fixed', 'absolute'].includes(getStyle(container, 'position'));
+
   while (calcContainer) {
     const overflow = getStyle(calcContainer, 'overflow');
+    // 若遇到滚动容器
     if (overflow?.match(/auto|scroll|hidden/)) {
-      return calcContainer;
+      // 若元素不是绝对定位元素，或滚动容器也是绝对定位元素，则使用改滚动容器作为视口
+      if (
+        !isPositionContainer ||
+        ['fixed', 'absolute'].includes(getStyle(calcContainer, 'position'))
+      ) {
+        return calcContainer;
+      }
     }
 
     calcContainer = calcContainer.parentNode as HTMLElement;
   }
 
+  // 其他情况均使用根节点作为视口
   return document.documentElement;
 }
 

--- a/test/placement.test.jsx
+++ b/test/placement.test.jsx
@@ -1,6 +1,3 @@
-import React, { useRef, useState, useEffect } from 'react';
-import ReactTestUtils, { act } from 'react-dom/test-utils';
-
 import getPlacements from '../src/placement';
 import { getStyle, getViewPort } from '../src/utils';
 
@@ -22,11 +19,11 @@ const container = mockElement({
   left: 0,
   top: 0,
   width: 1000,
-  height: 200,
+  height: 300,
   clientWidth: 1000,
-  clientHeight: 200,
+  clientHeight: 300,
   scrollWidth: 1000,
-  scrollHeight: 200,
+  scrollHeight: 300,
   scrollTop: 0,
   scrollLeft: 0,
   overflow: 'auto',
@@ -44,6 +41,34 @@ window.getComputedStyle = (node) => {
   };
 };
 
+function testBy({ target: t, container: c, placement: p, expect: e, adjustExpect: ae }) {
+  const { left: eLeft, top: eTop, placement: ePlacement } = e;
+  const config = {
+    target: mockElement({
+      ...target,
+      ...t,
+    }),
+    container: mockElement({ ...container, ...c }),
+    overlay,
+    placement: p,
+    autoAdjust: false,
+  };
+  const result = getPlacements(config);
+
+  expect(result.style.left).toBe(eLeft);
+  expect(result.style.top).toBe(eTop);
+
+  if (ae) {
+    const { left: aeLeft, top: aeTop, placement: aePlacement } = ae;
+    config.autoAdjust = true;
+    const result2 = getPlacements(config);
+
+    expect(result2.config.placement).toBe(aePlacement);
+    expect(result2.style.left).toBe(aeLeft);
+    expect(result2.style.top).toBe(aeTop);
+  }
+}
+
 describe('utils', () => {
   it('mock getStyle', () => {
     expect(getStyle(container, 'overflow')).toBe('auto');
@@ -55,79 +80,840 @@ describe('utils', () => {
 
 describe('placement', () => {
   it('should support placement=bl', () => {
-    const config = {
-      target,
-      container,
-      overlay,
+    testBy({
       placement: 'bl',
-      autoAdjust: false,
-    };
-
-    const result = getPlacements(config);
-
-    expect(result.style.left).toBe(target.left);
-    expect(result.style.top).toBe(target.height + target.top);
+      expect: {
+        left: target.left,
+        top: target.height + target.top,
+      },
+    });
   });
 
   it('should support autoAdjust placement=tl -> bl', () => {
-    const config = {
-      target,
-      container,
-      overlay,
+    testBy({
       placement: 'tl',
-      autoAdjust: false,
-    };
-
-    const result = getPlacements(config);
-
-    expect(result.style.left).toBe(target.left);
-    expect(result.style.top).toBe(target.top - overlay.height);
-
-    config.autoAdjust = true;
-    const result2 = getPlacements(config);
-
-    expect(result2.style.left).toBe(target.left);
-    expect(result2.style.top).toBe(target.height + target.top);
+      expect: {
+        left: target.left,
+        top: target.top - overlay.height,
+      },
+      adjustExpect: {
+        placement: 'bl',
+        left: target.left,
+        top: target.height + target.top,
+      },
+    });
   });
 
-  it('should support autoAdjust  placement=tr -> bl', () => {
-    const config = {
-      target,
-      container,
-      overlay,
+  it('should support autoAdjust placement=tr -> bl', () => {
+    testBy({
       placement: 'tr',
-      autoAdjust: false,
-    };
-
-    const result = getPlacements(config);
-
-    expect(result.style.left).toBe(target.left - overlay.width + target.width);
-    expect(result.style.top).toBe(target.top - overlay.height);
-
-    config.autoAdjust = true;
-    const result2 = getPlacements(config);
-
-    expect(result2.style.left).toBe(target.left);
-    expect(result2.style.top).toBe(target.height + target.top);
+      expect: {
+        left: target.left - overlay.width + target.width,
+        top: target.top - overlay.height,
+      },
+      adjustExpect: {
+        placement: 'bl',
+        left: target.left,
+        top: target.height + target.top,
+      },
+    });
   });
+
   it('should support autoAdjust make top/left > 0 placement=t -> b', () => {
-    const config = {
-      target,
-      container,
-      overlay,
+    testBy({
       placement: 't',
-      autoAdjust: false,
-    };
-
-    const result = getPlacements(config);
-
-    expect(result.style.left).toBe(target.left + target.width / 2 - overlay.width / 2);
-    expect(result.style.top).toBe(target.top - overlay.height);
-
-    config.autoAdjust = true;
-    const result2 = getPlacements(config);
-
-    expect(result2.style.left).toBe(0);
-    expect(result2.style.top).toBe(target.height + target.top);
+      expect: {
+        left: target.left + target.width / 2 - overlay.width / 2,
+        top: target.top - overlay.height,
+      },
+      adjustExpect: {
+        placement: 'bl',
+        left: target.left,
+        top: target.height + target.top,
+      },
+    });
   });
+
+  describe('should support autoAdjust when topOut', () => {
+    it('t -> b', () => {
+      testBy({
+        target: { left: 200, top: 0 },
+        placement: 't',
+        expect: {
+          left: 200 + target.width / 2 - overlay.width / 2,
+          top: 0 - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'b',
+          left: 200 + target.width / 2 - overlay.width / 2,
+          top: target.height,
+        },
+      });
+    });
+    it('tl -> bl, tr -> br', () => {
+      testBy({
+        target: { left: 200, top: 10 },
+        placement: 'tl',
+        expect: {
+          left: 200,
+          top: 10 - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'bl',
+          left: 200,
+          top: 10 + target.height,
+        },
+      });
+      testBy({
+        target: { left: 200, top: 10 },
+        placement: 'tr',
+        expect: {
+          left: 200 + target.width - overlay.width,
+          top: 10 - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'br',
+          left: 200 + target.width - overlay.width,
+          top: 10 + target.height,
+        },
+      });
+    });
+    it('l -> lt, r -> rt', () => {
+      testBy({
+        target: { left: 200, top: 10 },
+        placement: 'l',
+        expect: {
+          left: 200 - overlay.width,
+          top: 10 + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'lt',
+          left: 200 - overlay.width,
+          top: 10,
+        },
+      });
+      testBy({
+        target: { left: 200, top: 10 },
+        placement: 'r',
+        expect: {
+          left: 200 + target.width,
+          top: 10 + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'rt',
+          left: 200 + target.width,
+          top: 10,
+        },
+      });
+    });
+    it('lb -> lt, rb -> rt', () => {
+      testBy({
+        target: { left: 200, top: 10 },
+        placement: 'lb',
+        expect: {
+          left: 200 - overlay.width,
+          top: 10 + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'lt',
+          left: 200 - overlay.width,
+          top: 10,
+        },
+      });
+      testBy({
+        target: { left: 200, top: 10 },
+        placement: 'rb',
+        expect: {
+          left: 200 + target.width,
+          top: 10 + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'rt',
+          left: 200 + target.width,
+          top: 10,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when rightOut', () => {
+    const targetLeft = container.width - target.width;
+    const targetTop = 120;
+    it('r -> l', () => {
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 'r',
+        expect: {
+          left: targetLeft + target.width,
+          top: targetTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'l',
+          left: targetLeft - overlay.width,
+          top: targetTop + target.height / 2 - overlay.height / 2,
+        },
+      });
+    });
+
+    it('rt -> lt, rb -> lb', () => {
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 'rt',
+        expect: {
+          left: targetLeft + target.width,
+          top: targetTop,
+        },
+        adjustExpect: {
+          placement: 'lt',
+          left: targetLeft - overlay.width,
+          top: targetTop,
+        },
+      });
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 'rb',
+        expect: {
+          left: targetLeft + target.width,
+          top: targetTop + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'lb',
+          left: targetLeft - overlay.width,
+          top: targetTop + target.height - overlay.height,
+        },
+      });
+    });
+
+    it('t -> tr, b -> br', () => {
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 't',
+        expect: {
+          left: targetLeft + target.width / 2 - overlay.width / 2,
+          top: targetTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'tr',
+          left: targetLeft + target.width - overlay.width,
+          top: targetTop - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 'b',
+        expect: {
+          left: targetLeft + target.width / 2 - overlay.width / 2,
+          top: targetTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'br',
+          left: targetLeft + target.width - overlay.width,
+          top: targetTop + target.height,
+        },
+      });
+    });
+
+    it('tl -> tr, bl -> br', () => {
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 'tl',
+        expect: {
+          left: targetLeft,
+          top: targetTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'tr',
+          left: targetLeft + target.width - overlay.width,
+          top: targetTop - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: targetLeft, top: targetTop },
+        placement: 'bl',
+        expect: {
+          left: targetLeft,
+          top: targetTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'br',
+          left: targetLeft + target.width - overlay.width,
+          top: targetTop + target.height,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when bottomOut', () => {
+    const tLeft = 220;
+    const tTop = container.height - target.height;
+    it('b -> t', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'b',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 't',
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop - overlay.height,
+        },
+      });
+    });
+    it('bl -> tl, br -> tr', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'bl',
+        expect: {
+          left: tLeft,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'tl',
+          left: tLeft,
+          top: tTop - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'bl',
+        expect: {
+          left: tLeft,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'tl',
+          left: tLeft,
+          top: tTop - overlay.height,
+        },
+      });
+    });
+    it('l -> lb, r -> rb', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'l',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'lb',
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'r',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'rb',
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+    });
+    it('lt -> lb, rt -> rb', () => {});
+  });
+  describe('should support autoAdjust when leftOut', () => {
+    const tLeft = 0;
+    const tTop = 120;
+    it('l -> r', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'l',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'r',
+          left: tLeft + target.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+      });
+    });
+    it('lt -> rt, lb -> rb', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'lt',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop,
+        },
+        adjustExpect: {
+          placement: 'rt',
+          left: tLeft + target.width,
+          top: tTop,
+        },
+      });
+
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'lb',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'rb',
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+    });
+    it('t -> tl, b -> bl', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 't',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'tl',
+          left: tLeft,
+          top: tTop - overlay.height,
+        },
+      });
+
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'b',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'bl',
+          left: tLeft,
+          top: tTop + target.height,
+        },
+      });
+    });
+    it('tr -> tl, br -> bl', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'tr',
+        expect: {
+          left: tLeft + target.width - overlay.width,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'tl',
+          left: tLeft,
+          top: tTop - overlay.height,
+        },
+      });
+
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'br',
+        expect: {
+          left: tLeft + target.width - overlay.width,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'bl',
+          left: tLeft,
+          top: tTop + target.height,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when topOut & leftOut', () => {
+    const tLeft = 0;
+    const tTop = 0;
+    it('t -> bl, tr -> bl, tl -> bl', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 't',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'bl',
+          left: tLeft,
+          top: tTop + target.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'tr',
+        expect: {
+          left: tLeft + target.width - overlay.width,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'bl',
+          left: tLeft,
+          top: tTop + target.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'tl',
+        expect: {
+          left: tLeft,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'bl',
+          left: tLeft,
+          top: tTop + target.height,
+        },
+      });
+    });
+    it('l -> rt, lb -> rt, lt -> rt', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'l',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'rt',
+          left: tLeft + target.width,
+          top: tTop,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'lb',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'rt',
+          left: tLeft + target.width,
+          top: tTop,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'lt',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop,
+        },
+        adjustExpect: {
+          placement: 'rt',
+          left: tLeft + target.width,
+          top: tTop,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when topOut & rightOut', () => {
+    const tLeft = container.width - target.width;
+    const tTop = 0;
+    it('t -> br, tl -> br, tr -> br', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 't',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'br',
+          left: tLeft + target.width - overlay.width,
+          top: tTop + target.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'tl',
+        expect: {
+          left: tLeft,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'br',
+          left: tLeft + target.width - overlay.width,
+          top: tTop + target.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'tr',
+        expect: {
+          left: tLeft + target.width - overlay.width,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'br',
+          left: tLeft + target.width - overlay.width,
+          top: tTop + target.height,
+        },
+      });
+    });
+    it('r -> lt, rb -> lt, rt -> lt', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'r',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'lt',
+          left: tLeft - overlay.width,
+          top: tTop,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'rb',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'lt',
+          left: tLeft - overlay.width,
+          top: tTop,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'rt',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop,
+        },
+        adjustExpect: {
+          placement: 'lt',
+          left: tLeft - overlay.width,
+          top: tTop,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when rightOut & bottomOut', () => {
+    const tLeft = container.width - target.width;
+    const tTop = container.height - target.height;
+    it('r -> lb, rt -> lb, rb -> lb', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'r',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'lb',
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'rt',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop,
+        },
+        adjustExpect: {
+          placement: 'lb',
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'rb',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'lb',
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+    });
+    it('b -> tr, bl -> tr, br -> tr', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'b',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'tr',
+          left: tLeft + target.width - overlay.width,
+          top: tTop - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'bl',
+        expect: {
+          left: tLeft,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'tr',
+          left: tLeft + target.width - overlay.width,
+          top: tTop - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'br',
+        expect: {
+          left: tLeft + target.width - overlay.width,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 'tr',
+          left: tLeft + target.width - overlay.width,
+          top: tTop - overlay.height,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when bottomOut & leftOut', () => {
+    const tLeft = 0;
+    const tTop = container.height - target.height;
+    it('l -> rb, lt -> rb, lb -> rb', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'l',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'rb',
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'lt',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop,
+        },
+        adjustExpect: {
+          placement: 'rb',
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+      testBy({
+        target: { left: tLeft, top: tTop },
+        placement: 'lb',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'rb',
+          left: tLeft + target.width,
+          top: tTop + target.height - overlay.height,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when topOut & leftOut & rightOut', () => {
+    const tLeft = 0;
+    const tTop = 0;
+    const cWidth = target.width;
+    // 若 target 在容器内，则仅在 t 的情况下有可能 左上右 都超出
+    it('t -> b', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        container: { width: cWidth, clientWidth: cWidth, scrollWidth: cWidth },
+        placement: 't',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop - overlay.height,
+        },
+        adjustExpect: {
+          placement: 'b',
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop + target.height,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when topOut & rightOut & bottomOut', () => {
+    const cHeight = target.height;
+    const tLeft = container.width - target.width;
+    const tTop = 0;
+    // 若 target 在容器内，则仅在 r 的情况下有可能 上右下 都超出
+    it('r -> l', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        container: { height: cHeight, clientHeight: cHeight, scrollHeight: cHeight },
+        placement: 'r',
+        expect: {
+          left: tLeft + target.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'l',
+          left: tLeft - overlay.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when rightOut & bottomOut & leftOut', () => {
+    const tLeft = 0;
+    const tTop = container.height - target.height;
+    const cWidth = target.width;
+    // 若 target 在容器内，则仅在 b 的情况下有可能 右下左 都超出
+    it('b -> t', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        container: { width: cWidth, clientWidth: cWidth, scrollWidth: cWidth },
+        placement: 'b',
+        expect: {
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop + target.height,
+        },
+        adjustExpect: {
+          placement: 't',
+          left: tLeft + target.width / 2 - overlay.width / 2,
+          top: tTop - overlay.height,
+        },
+      });
+    });
+  });
+  describe('should support autoAdjust when bottomOut & leftOut & topOut', () => {
+    const cHeight = target.height;
+    const tLeft = 0;
+    const tTop = 0;
+    // 若 target 在容器内，则仅在 l 的情况下有可能 上左下 都超出
+    it('l -> r', () => {
+      testBy({
+        target: { left: tLeft, top: tTop },
+        container: { height: cHeight, clientHeight: cHeight, scrollHeight: cHeight },
+        placement: 'l',
+        expect: {
+          left: tLeft - overlay.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+        adjustExpect: {
+          placement: 'r',
+          left: tLeft + target.width,
+          top: tTop + target.height / 2 - overlay.height / 2,
+        },
+      });
+    });
+  });
+  // 任意placement都不可能四面超出，不做测试
+  // describe('should do nothing when topOut & rightOut & bottomOut & leftOut', () => {});
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -202,5 +202,45 @@ describe('utils', () => {
       document.body.appendChild(app);
       expect(getViewPort(box)).toBe(app);
     });
+    it('when box is sticky', () => {
+      const box = createElement('box');
+      box.style.position = 'sticky';
+      const app = createElement('app');
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+    it('when box is sticky and parent is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'sticky';
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is sticky and ancestor is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'sticky';
+      const parent = createElement('parent');
+      parent.appendChild(box);
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(parent);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is sticky and parent is containingBlock and ancestor is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'sticky';
+      const parent = createElement('parent');
+      parent.style.transform = 'translate(1px)';
+      parent.appendChild(box);
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(parent);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,206 @@
+import { getViewPort } from '../src/utils';
+
+function createElement(className, tagName = 'div') {
+  const el = document.createElement(tagName);
+  el.classList.add(className);
+  return el;
+}
+
+// polyfill offsetParent
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+// https://github.com/jsdom/jsdom/issues/1261
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+  get() {
+    // display none will return null;
+    for (let el = this; el; el = el.parentNode) {
+      if (el.style?.display?.toLowerCase() === 'none') {
+        return null;
+      }
+    }
+
+    // fixed return null
+    if (this.style?.position?.toLowerCase() === 'fixed') {
+      return null;
+    }
+
+    // html body element return null
+    if (this.tagName.toLowerCase() in ['html', 'body']) {
+      return null;
+    }
+
+    // positioned element
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/position
+    if (this.style.position && this.style.position.toLowerCase() !== 'static') {
+      const isMatch =
+        this.style.position.toLowerCase() === 'sticky'
+          ? (el) => {
+              return el.style?.overflow && el.style.overflow.toLowerCase() !== 'visible';
+            }
+          : (el) => {
+              // containing block 情况这里只模拟transform类型
+              if (el.style?.transform && el.style.transform !== 'none') {
+                return true;
+              }
+              return el.style?.position && el.style.position.toLowerCase() !== 'static';
+            };
+      for (let el = this.parentNode; el; el = el.parentNode) {
+        if (isMatch(el)) {
+          return el;
+        }
+      }
+      return document.body;
+    }
+
+    return this.parentNode;
+  },
+});
+
+describe('utils', () => {
+  describe('getViewport', () => {
+    it('normal', () => {
+      const box = createElement('box');
+      const app = createElement('app');
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+    it('when box is clipped', () => {
+      const box = createElement('box');
+      box.style.overflow = 'auto';
+      const app = createElement('app');
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(box);
+    });
+    it('when parent is clipped', () => {
+      const box = createElement('box');
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when ancestor element is clipped', () => {
+      const box = createElement('box');
+      const parent = createElement('parent');
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      parent.appendChild(box);
+      app.appendChild(parent);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is absoluted', () => {
+      const box = createElement('box');
+      box.style.position = 'absolute';
+      const app = createElement('app');
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+    it('when box is absoluted and parent is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'absolute';
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+    it('when box is absoluted and parent is clipped&relative', () => {
+      const box = createElement('box');
+      box.style.position = 'absolute';
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.style.position = 'relative';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is absoluted and parent is relative and ancestor is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'absolute';
+      const parent = createElement('parent');
+      parent.style.position = 'relative';
+      parent.appendChild(box);
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(parent);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is absoluted and parent is clipped&containingBlock', () => {
+      const box = createElement('box');
+      box.style.position = 'absolute';
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.style.transform = 'translate(1px)';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is absoluted and parent is containingBlock and ancestor is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'absolute';
+      const parent = createElement('parent');
+      parent.style.transform = 'translate(1px)';
+      parent.appendChild(box);
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(parent);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+
+    it('when box is fixed', () => {
+      const box = createElement('box');
+      box.style.position = 'fixed';
+      const app = createElement('app');
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+
+    it('when box is fixed and parent is relative', () => {
+      const box = createElement('box');
+      box.style.position = 'fixed';
+      const app = createElement('app');
+      app.style.position = 'relative';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+
+    it('when box is fixed and parent is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'fixed';
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(document.documentElement);
+    });
+    it('when box is fixed and parent is clipped&containingBlock', () => {
+      const box = createElement('box');
+      box.style.position = 'fixed';
+      const app = createElement('app');
+      app.style.transform = 'translate(1px)';
+      app.style.overflow = 'auto';
+      app.appendChild(box);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+    it('when box is fixed and parent is containingBlock and ancestor is clipped', () => {
+      const box = createElement('box');
+      box.style.position = 'fixed';
+      const parent = createElement('parent');
+      parent.style.transform = 'translate(1px)';
+      parent.appendChild(box);
+      const app = createElement('app');
+      app.style.overflow = 'auto';
+      app.appendChild(parent);
+      document.body.appendChild(app);
+      expect(getViewPort(box)).toBe(app);
+    });
+  });
+});


### PR DESCRIPTION
close https://github.com/alibaba-fusion/next/issues/4137

改动点:
1. overlay参考可视区域获取逻辑优化，原先只是寻找最近的滚动容器或浏览器视口，当在 followTrigger = true 且trigger的父容器是一个绝对定位跳出了它最近的滚动容器的情况下，需要使用浏览器视口作为参考可视区域。
2. autoAdjust调整逻辑重构 [New](https://github.com/alibaba-fusion/overlay/issues/23)，原先只是按照这个逻辑[Old](https://github.com/alibaba-fusion/overlay/issues/2)，尝试两次调整(其中遗漏了 t、r、b、l情况下调整 align位置的逻辑)，并在最后做一个基于 left, top 的兜底调整，重构为基于当前基于 视口（或滚动容器）的上下左右超出情况，尝试所有可能的placement，并在最后做一个基于placement的兜底调整（三侧超出，无法调整到合适位置的情况）。