### PR TITLE
fix: back adjust x&y while overlay is oversized

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 # 忽略目录
 build/
+es/
+lib/
 node_modules/
 **/*-min.js
 **/*.min.js

--- a/demo/autoAdjust.md
+++ b/demo/autoAdjust.md
@@ -5,6 +5,8 @@ order: 7
 
 能够根据空间大小自动更换 placement
 
+> 若调整后位置始终不符合预期，可能是渲染过程中overlay内容宽度发生了变化导致计算错误，可以尝试固定overlay内容宽度来解决
+
 ```jsx
 import { useState } from 'react';
 import Overlay from '@alifd/overlay';

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -254,11 +254,12 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>((props, ref) => {
       beforePosition,
       autoAdjust,
       rtl,
+      autoHideScrollOverflow: others.autoHideScrollOverflow,
     });
 
     if (!isSameObject(positionStyleRef.current, placements.style)) {
       positionStyleRef.current = placements.style;
-      setStyle(overlayNode, { ...placements.style, visibility: '' });
+      setStyle(overlayNode, placements.style);
       typeof onPosition === 'function' && onPosition(placements);
     }
   });
@@ -284,17 +285,11 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>((props, ref) => {
 
         overflowRef.current = getOverflowNodes(targetNode, containerNode);
 
-        // 1. 这里提前先设置好 position 属性，因为有的节点可能会因为设置了 position 属性导致宽度变小
-        // 2. 设置 visibility 先把弹窗藏起来，避免影响视图
-        // 3. 因为未知原因，原先 left&top 设置为 -1000的方式隐藏会导致获取到的overlay元素宽高不对
-        // https://drafts.csswg.org/css-position/#abspos-layout 未在此处找到相关解释，可能是浏览器优化，但使其有部分在可视区域内，就可以获取到渲染后正确的宽高, 然后使用visibility隐藏
-        const nodeRect = getWidthHeight(node);
+        // fixme: 在followTrigger且空间受限且overlay自动宽度情况下，overlay宽度会跟随left设定自动撑满containing block最右侧，这里建议手动设定overlay宽度或拥有固定内容宽度的overlay来解决，这里暂时使用原来的-1000位置的方案隐藏overlay并不影响容器宽高
         setStyle(node, {
           position: fixed ? 'fixed' : 'absolute',
-          // 这里 -nodeRect.width 是避免添加到容器内导致容器出现宽高变化， +1 是为了能确保有一部分在可视区域内
-          top: -nodeRect.height + 1,
-          left: -nodeRect.width + 1,
-          visibility: 'hidden',
+          top: -1000,
+          left: -1000,
         });
 
         const waitTime = 100;

--- a/src/placement.ts
+++ b/src/placement.ts
@@ -619,13 +619,13 @@ export default function getPlacements(config: PlacementsConfig): PositionResult 
       top = adjustResult.top;
       placement = adjustResult.placement;
     }
-  }
 
-  const adjustXYResult = adjustXY(left, top, placement, staticInfo);
-  if (adjustXYResult) {
-    left = adjustXYResult.left;
-    top = adjustXYResult.top;
-    placement = adjustXYResult.placement;
+    const adjustXYResult = adjustXY(left, top, placement, staticInfo);
+    if (adjustXYResult) {
+      left = adjustXYResult.left;
+      top = adjustXYResult.top;
+      placement = adjustXYResult.placement;
+    }
   }
 
   const result: PositionResult = {

--- a/test/placement.test.jsx
+++ b/test/placement.test.jsx
@@ -842,7 +842,7 @@ describe('placement', () => {
         },
         adjustExpect: {
           placement: 'b',
-          left: tLeft + target.width / 2 - overlay.width / 2,
+          left: Math.max(0, tLeft + target.width / 2 - overlay.width / 2),
           top: tTop + target.height,
         },
       });
@@ -865,7 +865,7 @@ describe('placement', () => {
         adjustExpect: {
           placement: 'l',
           left: tLeft - overlay.width,
-          top: tTop + target.height / 2 - overlay.height / 2,
+          top: Math.max(0, tTop + target.height / 2 - overlay.height / 2),
         },
       });
     });
@@ -886,7 +886,7 @@ describe('placement', () => {
         },
         adjustExpect: {
           placement: 't',
-          left: tLeft + target.width / 2 - overlay.width / 2,
+          left: Math.max(0, tLeft + target.width / 2 - overlay.width / 2),
           top: tTop - overlay.height,
         },
       });
@@ -909,7 +909,7 @@ describe('placement', () => {
         adjustExpect: {
           placement: 'r',
           left: tLeft + target.width,
-          top: tTop + target.height / 2 - overlay.height / 2,
+          top: Math.max(0, tTop + target.height / 2 - overlay.height / 2),
         },
       });
     });


### PR DESCRIPTION
1. 添加基于 x y 调整的兜底逻辑:
   1. overlay尺寸大于滚动视口尺寸情况，根据rtl设置，强制对齐习惯侧边缘
 
   2. 不大于情况，哪边超出，哪边重置为边缘位置

2. 调整时，参考容器改为viewport

3. pass autoHideScrollOverflow